### PR TITLE
 add strings en #9 

### DIFF
--- a/app/src/main/java/com/alphanication/rebirth/di/NetworkModule.kt
+++ b/app/src/main/java/com/alphanication/rebirth/di/NetworkModule.kt
@@ -57,7 +57,7 @@ object NetworkModule {
 }
 
 class ErrorInterceptor(
-    private val networkMonitor: NetworkMonitor,
+    private val networkMonitor: NetworkMonitor
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/app/src/main/java/com/alphanication/rebirth/ui/base/BaseFragment.kt
+++ b/app/src/main/java/com/alphanication/rebirth/ui/base/BaseFragment.kt
@@ -2,9 +2,21 @@ package com.alphanication.rebirth.ui.base
 
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import com.alphanication.rebirth.domain.repository.NetworkMonitor
+import javax.inject.Inject
 
 abstract class BaseFragment : Fragment() {
 
-    fun showError(message: String) =
-        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    @Inject
+    lateinit var networkMonitor: NetworkMonitor
+
+    fun showError(message: String) {
+        /** Воробей Е. А., 07.01.2023
+         * Strategical exception handler выставлен на уровне interceptor'a retrofit */
+        if (networkMonitor.isConnected()) Toast.makeText(
+            requireContext(),
+            message,
+            Toast.LENGTH_SHORT
+        ).show()
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,11 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Rebirth</string>
 
     <!-- Base -->
-    <string name="network_error">Отсутствует подключение к Интернету.</string>
+    <string name="network_error">There is no Internet connection.</string>
 
     <!-- Main Quote Fragment -->
     <string name="impossible_or_im_possible">impossible or i\'m possible?</string>
     <string name="author_c">© &#160;</string>
-    <string name="anonymous">неизвестная личность</string>
+    <string name="anonymous">unknown person.</string>
 </resources>


### PR DESCRIPTION
 Добавить strings на en и реализовать переводы к ним.
Подкорректировать обработку ошибок base fragment showError() - не показывать ошибки при отсутствии интернет-соединения, т.к. данная обработка выставлена на уровне interceptor'a retrofit.